### PR TITLE
fixing int parse error

### DIFF
--- a/detectors/yolo.py
+++ b/detectors/yolo.py
@@ -50,8 +50,8 @@ def get_bounding_boxes(image):
                 center_y = int(detection[1] * height)
                 w = int(detection[2] * width)
                 h = int(detection[3] * height)
-                x = center_x - w / 2
-                y = center_y - h / 2
+                x = int(center_x - w / 2)
+                y = int(center_y - h / 2)
                 classes.append(CLASSES[class_id])
                 confidences.append(float(confidence))
                 boxes.append([x, y, w, h])


### PR DESCRIPTION
File "/home/davo/Downloads/TProjects/ivy/main.py", line 111, in run
object_counter.count(frame)
File "/home/davo/Downloads/TProjects/ivy/ObjectCounter.py", line 74, in count
self.blobs = add_new_blobs(_bounding_boxes, _classes, _confidences, self.blobs, self.frame, self.tracker, self.mcdf)
File "/home/davo/Downloads/TProjects/ivy/tracker.py", line 66, in add_new_blobs
_tracker = get_tracker(tracker, box, frame)
File "/home/davo/Downloads/TProjects/ivy/tracker.py", line 40, in get_tracker
return _kcf_create(bounding_box, frame)
File "/home/davo/Downloads/TProjects/ivy/tracker.py", line 30, in _kcf_create
tracker.init(frame, tuple(bounding_box))
TypeError: integer argument expected, got float

I parsed the x and y coordinates to int of the bounding box in yolo.py script

x = int(center_x - w / 2)
y = int(center_y - h / 2)

and now it runs correctly.